### PR TITLE
BUGFIX nickname and username

### DIFF
--- a/commands/points.js
+++ b/commands/points.js
@@ -17,8 +17,10 @@ function howManyPoints(userID, cb) {
     pointsAdd.findOne({userid: userID}, (err, pointdata) => {
         if(err) 
             return cb(err, null);
-        if(pointdata)
+        if(pointdata) {
+            //console.log(pointdata.points);
             return cb(null, pointdata.points);
+        }
         else
             return cb(null, null);
     })
@@ -31,18 +33,18 @@ function howManyPoints(userID, cb) {
  */
 function findPoints(msg, userID){
 
-    howManyPoints(userID, (err, points) => {
+    howManyPoints(userID, (err, pointdata) => {
         if(err){
             console.log(err);
         }
-        else if(points){
+        else if(pointdata){
             const embedMsg = new Discord.MessageEmbed()
             .setColor('#2f3136')
-            .setDescription(`${userID} has **${(points)}** points.`);
+            .setDescription(`${userID} has **${(pointdata)}** points.`);
             msg.channel.send(embedMsg);
         }
         else{
-            msg.channel.send(`${userID}, you do not have any points! Please contribute by answering questions to get started.`);
+            msg.channel.send(`User does not have any points!`);
         }
     });
 }
@@ -69,13 +71,16 @@ module.exports = {
     execute (prefix, msg, args){
         //if command doesnt have any arguments "-points"
         if(!args.length){
-            findPoints(msg, msg.author);
+            // Removes nickname ! in ID
+            let thisUser = String(msg.member).replace('!','');
+            findPoints(msg, thisUser);
         }
 
         //if command has one argument "-points @user" and it's a mention
         else if(args.length === 1 && args[0].startsWith('<@') && args[0].endsWith('>')){
-            let mention = msg.mentions.users.first();
-            findPoints(msg, mention);
+            // Removes nickname ! in ID
+            let thisUser = String(msg.mentions.users.first()).replace('/!','/');;
+            findPoints(msg, thisUser);
         }
 
         //every other condition is incorrect

--- a/commands/pointsMod.js
+++ b/commands/pointsMod.js
@@ -100,54 +100,47 @@ module.exports = {
     description: "this mod command changes the points of a user",
     execute (prefix, msg, args){
         if (args.length > 0){
-            let mention = args[0];
-            if(mention.startsWith('<@') && mention.endsWith('>') && args.length <= 3){
-                
-                let doCommand = args[1];
-                
-                switch(doCommand) {
-                    case 'inc':
-                        let increment = args[2];
-                        if (!isNaN(parseInt(increment))){
-                            decPoints(msg, mention, increment*(-1));
-                        }
-                        else {
-                            msg.channel.send(`Correct usage: \`${prefix}points <user> inc <points>\``);
-                        }
-                        break;
-                    case 'dec':
-                        let deincrement = args[2];
-                        if (!isNaN(parseInt(deincrement))){
-                            decPoints(msg, mention, deincrement);
-                        }
-                        else {
-                            msg.channel.send(`Correct usage: \`${prefix}points <user> dec <points>\``);
-                        }
-                        break;
-                    case 'set':
-                        let set = args[2];
-                        if (!isNaN(parseInt(set))){
-                            setPoints(msg, mention, set);
-                        }
-                        else {
-                            msg.channel.send(`Correct usage: \`${prefix}points <user> set <points>\``);
-                        }
-                        break;
-                    case 'pen':
-                        decPoints(msg, mention, 1000);
-                        break;
-                    default:
-                        incorrectUsage(prefix, msg);
-                        break;
-                }
+            // Removes nickname ! in ID
+            let mention = String(msg.mentions.users.first()).replace('!','');
+            let doCommand = args[1];
+            switch(doCommand) {
+                case 'inc':
+                    let increment = args[2];
+                    if (!isNaN(parseInt(increment))){
+                        decPoints(msg, mention, increment*(-1));
+                    }
+                    else {
+                        msg.channel.send(`Correct usage: \`${prefix}points <user> inc <points>\``);
+                    }
+                    break;
+                case 'dec':
+                    let deincrement = args[2];
+                    if (!isNaN(parseInt(deincrement))){
+                        decPoints(msg, mention, deincrement);
+                    }
+                    else {
+                        msg.channel.send(`Correct usage: \`${prefix}points <user> dec <points>\``);
+                    }
+                    break;
+                case 'set':
+                    let set = args[2];
+                    if (!isNaN(parseInt(set))){
+                        setPoints(msg, mention, set);
+                    }
+                    else {
+                        msg.channel.send(`Correct usage: \`${prefix}points <user> set <points>\``);
+                    }
+                    break;
+                case 'pen':
+                    decPoints(msg, mention, 1000);
+                    break;
+                default:
+                    incorrectUsage(prefix, msg);
+                    break;
             }
-            else {
-                incorrectUsage(prefix, msg);
-            }
-        } 
+        }
         else {
             incorrectUsage(prefix, msg);
         }
-        
     }
 }

--- a/commands/rankup.js
+++ b/commands/rankup.js
@@ -31,10 +31,13 @@ function howManyPoints(thisUser, cb) {
     pointsAdd.findOne({userid: thisUser}, (err, pointdata) => {
         if(err) 
             return cb(err, null);
-        if(pointdata)
+        if(pointdata) {
+            //console.log(pointdata.points);
             return cb(null, pointdata.points);
-        else
+        }
+        else {
             return cb(null, null);
+        }
     })
 }
 
@@ -52,17 +55,17 @@ function howManyPoints(thisUser, cb) {
 function doRankUp(msg, thisUser, roleNames, rolePoints, index) {
     
     //If user does not have the role
-    if (!thisUser.roles.cache.has(roleNames[index].id)){
+    if (!msg.member.roles.cache.has(roleNames[index].id)){
         //Remove roles if the user has them
-        repairRoles(thisUser, rolePoints, roleNames);
+        repairRoles(msg.member, rolePoints, roleNames);
 
-        thisUser.roles.add(roleNames[index].id);
+        msg.member.roles.add(roleNames[index].id);
         const embedMsg = new Discord.MessageEmbed()
         .setColor('#2ecc71')
         if (index === 5){
-            embedMsg.setDescription(`${thisUser} has ranked up to ${roleNames[index]}!\nCongrats, you now have access to the members chats!`);
+            embedMsg.setDescription(`${msg.member} has ranked up to ${roleNames[index]}!\nCongrats, you now have access to the members chats!`);
         } else {
-            embedMsg.setDescription(`${thisUser} has ranked up to ${roleNames[index]}!\n`);
+            embedMsg.setDescription(`${msg.member} has ranked up to ${roleNames[index]}!\n`);
         }
         msg.channel.send(embedMsg);
     }
@@ -101,7 +104,7 @@ function doRankUp(msg, thisUser, roleNames, rolePoints, index) {
 function hasNoRank(msg, thisUser, roleNames, rolePoints,) {
 
     //Check if user somehow has a role already. If they do, remove it.
-    repairRoles(thisUser, rolePoints, roleNames);
+    repairRoles(msg.member, rolePoints, roleNames);
 
     howManyPoints(thisUser, (err, points) => {
         if(err)
@@ -125,43 +128,48 @@ function hasNoRank(msg, thisUser, roleNames, rolePoints,) {
  */
 function rankupCheck(msg, roleNames, rolePoints) {
     
-    let thisUser = msg.member;
-    howManyPoints(thisUser, (err, points) => {
-        if(err)
+    // Removes nickname ! in ID
+    let thisUser = String(msg.member).replace('!','');
+    
+    howManyPoints(thisUser, (err, pointdata) => {
+        if(err) {
             console.log(err);
-        else if(points){
+        }
+        else if(pointdata){
             switch (true) {
-                case points >= rolePoints[5]:
+                case pointdata >= rolePoints[5]:
                     doRankUp(msg, thisUser, roleNames, rolePoints, 5);
                     break;
-                case points >= rolePoints[4] && points < rolePoints[5]:
+                case pointdata >= rolePoints[4] && pointdata < rolePoints[5]:
                     doRankUp(msg, thisUser, roleNames, rolePoints, 4);
                     break;
-                case points >= rolePoints[3] && points < rolePoints[4]:
+                case pointdata >= rolePoints[3] && pointdata < rolePoints[4]:
                     doRankUp(msg, thisUser, roleNames, rolePoints, 3);
                     break;
-                case points >= rolePoints[2] && points < rolePoints[3]:
+                case pointdata >= rolePoints[2] && pointdata < rolePoints[3]:
                     doRankUp(msg, thisUser, roleNames, rolePoints, 2);
                     break;    
-                case points >= rolePoints[1] && points < rolePoints[2]:
+                case pointdata >= rolePoints[1] && pointdata < rolePoints[2]:
                     doRankUp(msg, thisUser, roleNames, rolePoints, 1);
                     break;    
-                case points >= rolePoints[0] && points < rolePoints[1]:
+                case pointdata >= rolePoints[0] && pointdata < rolePoints[1]:
                     doRankUp(msg, thisUser, roleNames, rolePoints, 0);
                     break;
-                case points <  rolePoints[0]:
+                case pointdata <  rolePoints[0]:
                     hasNoRank(msg, thisUser, roleNames, rolePoints);
                     break;
-                case points === 0:
-                    repairRoles(thisUser, rolePoints, roleNames);
+                case pointdatas === 0:
+                    repairRoles(msg.member, rolePoints, roleNames);
                     msg.channel.send(`${thisUser}, you do not have any points! Please contribute by answering questions to get started.`);
                 default:
                     msg.channel.send(`${thisUser}, you do not have any points! Please contribute by answering questions to get started.`);
                     break;
             }
         }
-        else
-            repairRoles(thisUser, rolePoints, roleNames);
+        else {
+            msg.channel.send(`**${thisUser}**, you do not have any points! Please contribute by answering questions to get started.`);
+            repairRoles(msg.member, rolePoints, roleNames);
+        }
     });
 }
 

--- a/commands/thanks.js
+++ b/commands/thanks.js
@@ -78,6 +78,9 @@ function idToName(arr){
  */
 function thank (usersID, score) {
     
+    // Removes nickname ! in ID
+    usersID = String(usersID).replace('!','');
+    
     pointsAdd.findOne({userid: usersID}, (err, pointdata) => {
         if(err) console.log(err);
         if(!pointdata){


### PR DESCRIPTION
This commit fixes a bug that creates and updates a separate schema if the Discord user has a nickname.
For example `@chendumpling#6818` has the ID `<@189549341642326018>` but `@chicken` has the ID `<@!189549341642326018>`. The fix removes the ! from the ID.